### PR TITLE
feat: add basic frontend layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,17 @@
+async function loadCards() {
+  try {
+    const res = await fetch('/cards');
+    const data = await res.json();
+    const grid = document.getElementById('card-grid');
+    data.forEach(card => {
+      const div = document.createElement('div');
+      div.className = 'card';
+      div.textContent = card.name || card.id;
+      grid.appendChild(div);
+    });
+  } catch (err) {
+    console.error('Erro ao carregar cartas', err);
+  }
+}
+
+loadCards();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>TCG Collection</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>TCG Collection</h1>
+    <nav>
+      <ul>
+        <li><a href="#cards">Cartas</a></li>
+        <li><a href="#collection">Coleção</a></li>
+        <li><a href="#wishlist">Wishlist</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section id="cards">
+      <h2>Cartas</h2>
+      <div id="card-grid" class="grid"></div>
+    </section>
+    <section id="collection">
+      <h2>Sua Coleção</h2>
+      <div id="collection-list" class="grid"></div>
+    </section>
+    <section id="wishlist">
+      <h2>Wishlist</h2>
+      <div id="wishlist-list" class="grid"></div>
+    </section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,47 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #f2f2f2;
+  color: #333;
+}
+
+header {
+  background-color: #e3350d;
+  color: white;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+nav a {
+  color: white;
+  text-decoration: none;
+  font-weight: bold;
+}
+
+main {
+  padding: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background-color: white;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 0.5rem;
+  text-align: center;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 const express = require('express');
+const path = require('path');
 
 const app = express();
 app.use(express.json());
 
-// Root endpoint
+// Serve static files for the front-end layout
+const publicDir = path.join(__dirname, '..', 'public');
+app.use(express.static(publicDir));
+
+// Root endpoint serves the layout
 app.get('/', (req, res) => {
-  res.json({ message: 'TCG Collection API' });
+  res.sendFile(path.join(publicDir, 'index.html'));
 });
 
 // Cards routes


### PR DESCRIPTION
## Summary
- serve static frontend with Express
- add basic layout for cards, collection, and wishlist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28041b20883248a677a9d768bf95e