### PR TITLE
Fix wishlist routing and clean up imports

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,23 @@
+"""Application entry point for the TCG Collection API.
+
+This module creates the :class:`FastAPI` application instance and registers
+all available routers.  During the initial scaffold of this repository the
+file accidentally instantiated the application twice which meant that only
+the routes registered after the second instantiation were exposed.  The
+wishlist endpoints used in the tests were therefore missing.  The revised
+implementation below ensures the app is created a single time and that all
+routers are included.
+"""
+
 from fastapi import FastAPI
-from routes import wishlist
+from routes import cards, sets, wishlist
 
-app = FastAPI()
-app.include_router(wishlist.router)
-from .routes import sets, cards
 
+# Create the FastAPI app and register all routers.
 app = FastAPI(title="TCG Collection API")
-
+app.include_router(wishlist.router)
 app.include_router(sets.router)
 app.include_router(cards.router)
+
+
+__all__ = ["app"]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,4 +1,18 @@
-from sqlalchemy.orm import declarative_base
+"""Database model base class.
 
-Base = declarative_base()
+The project makes use of SQLAlchemy for persisting some models, but the test
+environment used in this kata does not install SQLAlchemy.  Importing
+``models`` therefore previously failed during module initialisation.  To keep
+the models package lightweight and to allow the Pydantic models (such as the
+``WishlistItem``) to be imported without SQLAlchemy being present, we attempt
+to import :func:`declarative_base` and fall back to a simple stub when the
+dependency is missing.
+"""
+
+try:  # pragma: no cover - optional dependency handling
+    from sqlalchemy.orm import declarative_base
+    Base = declarative_base()
+except ModuleNotFoundError:  # SQLAlchemy not installed
+    class Base:  # type: ignore[override]
+        """Fallback base class used when SQLAlchemy is unavailable."""
 

--- a/src/routes/cards.py
+++ b/src/routes/cards.py
@@ -1,5 +1,11 @@
 from fastapi import APIRouter, HTTPException
-from ..services import cards as cards_service
+
+# Import the card service using an absolute import.  The previous relative
+# import attempted to traverse beyond the top-level package when the module
+# was imported as part of the application start-up, leading to an
+# ``ImportError``.  Using an absolute import keeps the module usable both when
+# running the app and during test collection.
+from services import cards as cards_service
 
 router = APIRouter(prefix="/cards", tags=["cards"])
 

--- a/src/routes/sets.py
+++ b/src/routes/sets.py
@@ -1,5 +1,9 @@
 from fastapi import APIRouter, HTTPException
-from ..services import sets as sets_service
+
+# Similar to the cards route, use an absolute import for the service layer to
+# avoid issues when the module is imported as part of the application
+# initialisation.
+from services import sets as sets_service
 
 router = APIRouter(prefix="/sets", tags=["sets"])
 


### PR DESCRIPTION
## Summary
- ensure FastAPI app registers wishlist, cards and sets routers
- avoid SQLAlchemy dependency in models package
- use absolute imports in cards and sets routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2844939c88324824479f2420dd858